### PR TITLE
chat-spaceメッセージ送信機能の実装（修正）

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,7 +2,7 @@ class Message < ApplicationRecord
   belongs_to :user
   belongs_to :group
   
-  validates :content, presence: true, unless: :image?
+  validates :text, presence: true, unless: :image?
   
   mount_uploader :image, ImageUploader
 end


### PR DESCRIPTION
# what
動作確認を行ったところ、メッセージを送信時にエラーが出ましたので原因を特定して内容を修正しました。
バリデーションでテキストの空制約をかけていますが、そのクラス名が間違っていたため。

# why
エラー表示を直さないとアプリとして完成しないため